### PR TITLE
GoogleMapAPIの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@
 /node_modules
 
 /public/uploads
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,10 @@ gem 'rails-i18n', '~> 7.0.0'
 #画像アップロード
 gem 'carrierwave'
 
+# 環境変数管理
+gem 'gon'
+gem 'dotenv-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,10 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
     faker (3.4.1)
@@ -122,6 +126,11 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -151,6 +160,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.23.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mutex_m (0.2.0)
     net-imap (0.4.12)
       date
@@ -237,6 +247,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rexml (3.3.0)
       strscan
     ruby-vips (2.2.1)
@@ -295,7 +307,9 @@ DEPENDENCIES
   carrierwave
   cssbundling-rails
   debug
+  dotenv-rails
   faker
+  gon
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,15 @@
 class StaticPagesController < ApplicationController
+
+  before_action :set_google_maps_api_key
+
   def top
     @q = Shop.ransack(params[:q])
   end
+
+  private
+
+  def set_google_maps_api_key
+    gon.google_maps_api_key = ENV['GOOGLE_MAPS_API_KEY']
+  end
+
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import './custom/googlemap'
+
+const KEY = gon.google_maps_api_key;

--- a/app/javascript/custom/googlemap.js
+++ b/app/javascript/custom/googlemap.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// [START maps_add_map]
+// Initialize and add the map
+let map;
+
+async function initMap() {
+  // [START maps_add_map_instantiate_map]
+  // The location of Uluru
+  const position = { lat: 35.68978920591743, lng: 139.70055989948156 };
+  // Request needed libraries.
+  //@ts-ignore
+  const { Map } = await google.maps.importLibrary("maps");
+  const { AdvancedMarkerView } = await google.maps.importLibrary("marker");
+
+  // The map, centered at Uluru
+  map = new Map(document.getElementById("map"), {
+    zoom: 15,
+    center: position,
+    mapId: "DEMO_MAP_ID",
+  });
+
+  // [END maps_add_map_instantiate_map]
+  // [START maps_add_map_instantiate_marker]
+  // The marker, positioned at Uluru
+  const marker = new AdvancedMarkerView({
+    map: map,
+    position: position,
+    title: "Uluru",
+  });
+  // [END maps_add_map_instantiate_marker]
+}
+
+initMap();
+// [END maps_add_map]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= include_gon %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -9,7 +9,32 @@
           </div>
         </div>
         <%= image_tag 'toppage.jpg' %>
+        <div id="map" style="height: 400px; width: 100%;"></div>
       </div>
     </div>
   </div>
 </div>
+
+<script>
+  (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
+    key: gon.google_maps_api_key,
+    v: "weekly",
+    // Use the 'v' parameter to indicate the version to use (weekly, beta, alpha, etc.).
+    // Add other bootstrap parameters as needed, using camel case.
+  });
+</script>
+
+<script>
+  let map;
+
+  async function initMap() {
+    const { Map } = await google.maps.importLibrary("maps");
+
+    map = new Map(document.getElementById("map"), {
+      center: { lat: -34.397, lng: 150.644 },
+      zoom: 8,
+    });
+  }
+
+  initMap();
+</script>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@hotwired/turbo-rails": "^8.0.4",
     "autoprefixer": "^10.4.19",
     "daisyui": "^4.12.2",
+    "dotenv": "^16.4.5",
     "esbuild": "^0.21.5",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,11 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"


### PR DESCRIPTION
close #48 

GoogleMapを表示

参考サイト
- Google Maps Platform
https://developers.google.com/maps/documentation/javascript/load-maps-js-api?hl=ja&_gl=1*f7b2vi*_up*MQ..*_ga*MTY5ODA1NzczLjE3MjE5MDkyNzI.*_ga_NRWSTWS78N*MTcyMTkwOTI3Mi4xLjAuMTcyMTkwOTI3Mi4wLjAuMA..
- 【Ruby】RailsでGoogle Maps API（Geocording）を導入しよう
https://zenn.dev/code_journey_ys/articles/594eb6153e29c8
- 【Rails on Rails】.envの環境変数をjsファイル内で利用する方法
https://qiita.com/ozkn666/items/9df680e53acb76c36e0a